### PR TITLE
Add CLI and visualization tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,12 +63,20 @@ mesh = [
     "open3d>=0.18.0",
 ]
 
+[project.scripts]
+fnirs = "fnirs.cli:app"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["fnirs*"]
 
 [tool.uv]
 constraint-dependencies = ["llvm>0.43.0"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]
 
 
 

--- a/src/fnirs/cli.py
+++ b/src/fnirs/cli.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Command-line interface for fnirs package."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+app = typer.Typer(help="fNIRS spatial-temporal modeling tools.")
+
+
+@app.command()
+def fit(
+    data: Path = typer.Option(..., help="Path to .mat or .snirf file"),
+    output: Path = typer.Option(..., help="Output directory for results"),
+    max_degree: int = typer.Option(5, help="Max spherical harmonics degree"),
+    n_fourier: Optional[int] = typer.Option(None, help="Number of frequency bins (default: all)"),
+    chromophore: str = typer.Option("hbo", help="Chromophore: hbo, hbr, or hbt"),
+    temporal_kernel: Optional[str] = typer.Option(None, help="Temporal kernel: matern12 or omit for none"),
+    kernel_lengthscale: float = typer.Option(1.0, help="Kernel lengthscale"),
+    kernel_variance: float = typer.Option(1.0, help="Kernel variance"),
+    estimate_noise: bool = typer.Option(False, help="Enable IRLS noise estimation"),
+    max_irls_iter: int = typer.Option(20, help="Max IRLS iterations"),
+    irls_tol: float = typer.Option(1e-4, help="IRLS convergence tolerance"),
+    seed: int = typer.Option(42, help="Random seed for train/test split"),
+):
+    """Fit a spatial-temporal model to fNIRS data."""
+    import numpy as np
+    import jax.numpy as jnp
+
+    from fnirs.io import load_hemodynamic_data, load_snirf_data, ChromophoreType
+    from fnirs.spherical_projection import project_fnirs_to_sphere
+    from fnirs.model import fit as model_fit
+
+    # Load data
+    data_path = str(data)
+    if data.suffix == ".snirf":
+        nirs_data = load_snirf_data(data_path)
+        Y = nirs_data.time_series.T  # (n_channels, n_timepoints)
+        positions_3d = nirs_data.get_spatial_coordinates_3d()
+        if positions_3d is None:
+            positions_3d = nirs_data.get_spatial_coordinates_2d()
+            # Pad to 3D
+            positions_3d = np.column_stack([positions_3d, np.zeros(len(positions_3d))])
+        t = jnp.array(nirs_data.time)
+    else:
+        hemo_data = load_hemodynamic_data(data_path)
+        chrom_map = {"hbo": ChromophoreType.HbO, "hbr": ChromophoreType.HbR, "hbt": ChromophoreType.HbT}
+        chrom = chrom_map[chromophore.lower()]
+        Y = hemo_data.get_concentration_matrix(chrom).T  # (n_channels, n_timepoints)
+        positions_3d = hemo_data.get_spatial_coordinates_3d()
+        t = jnp.array(hemo_data.time)
+
+    # Project to sphere
+    proj = project_fnirs_to_sphere(positions_3d)
+    theta = jnp.array(proj["theta"])
+    phi = jnp.array(proj["phi"])
+    Y = jnp.array(Y)
+
+    # Fit model
+    result = model_fit(
+        t=t,
+        θ=theta,
+        ϕ=phi,
+        Y=Y,
+        max_spherical_degree=max_degree,
+        n_fourier_components=n_fourier,
+        estimate_noise=estimate_noise,
+        max_irls_iter=max_irls_iter,
+        irls_tol=irls_tol,
+        temporal_kernel=temporal_kernel,
+        kernel_lengthscale=kernel_lengthscale,
+        kernel_variance=kernel_variance,
+    )
+
+    X_freq_full, predict_fn, _, ST, terms, noise_variance, n_iter = result
+
+    # Save results
+    output.mkdir(parents=True, exist_ok=True)
+
+    save_dict = dict(
+        X_freq_real=np.array(X_freq_full.real),
+        X_freq_imag=np.array(X_freq_full.imag),
+        ST=np.array(ST),
+        n_timepoints=int(Y.shape[1]),
+    )
+    # Save terms as arrays
+    terms_l = np.array([t[0] for t in terms])
+    terms_m = np.array([t[1] for t in terms])
+    save_dict["terms_l"] = terms_l
+    save_dict["terms_m"] = terms_m
+
+    if noise_variance is not None:
+        save_dict["noise_variance"] = np.array(noise_variance)
+
+    np.savez(output / "model.npz", **save_dict)
+
+    # Save config
+    config = dict(
+        data=str(data),
+        max_degree=max_degree,
+        n_fourier=n_fourier,
+        chromophore=chromophore,
+        temporal_kernel=temporal_kernel,
+        kernel_lengthscale=kernel_lengthscale,
+        kernel_variance=kernel_variance,
+        estimate_noise=estimate_noise,
+        max_irls_iter=max_irls_iter,
+        irls_tol=irls_tol,
+        seed=seed,
+    )
+    with open(output / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+
+    # Print summary
+    n_channels, n_timepoints = Y.shape
+    n_spatial = ST.shape[1]
+    n_freq = X_freq_full.shape[1]
+    typer.echo(f"Fit complete.")
+    typer.echo(f"  Channels: {n_channels}")
+    typer.echo(f"  Timepoints: {n_timepoints}")
+    typer.echo(f"  Spatial basis functions: {n_spatial}")
+    typer.echo(f"  Frequency bins: {n_freq}")
+    if noise_variance is not None:
+        typer.echo(f"  IRLS iterations: {n_iter}")
+        typer.echo(f"  Noise variance: min={float(noise_variance.min()):.6f}, max={float(noise_variance.max()):.6f}, median={float(jnp.median(noise_variance)):.6f}")
+    typer.echo(f"  Results saved to: {output}")
+
+
+@app.command()
+def plot(
+    model_dir: Path = typer.Option(..., help="Path to output from fnirs fit"),
+    data: Optional[Path] = typer.Option(None, help="Original data file (for residuals)"),
+    output: Optional[Path] = typer.Option(None, help="Directory for figures (default: model-dir/figures/)"),
+):
+    """Visualize a fitted model."""
+    import numpy as np
+
+    from fnirs.plotting import (
+        plot_harmonics_timeseries,
+        plot_residuals,
+        plot_noise_variance,
+        plot_power_spectrum,
+        plot_spatial_snapshot,
+    )
+
+    # Load model
+    model_data = np.load(model_dir / "model.npz")
+    X_freq = model_data["X_freq_real"] + 1j * model_data["X_freq_imag"]
+    ST = model_data["ST"]
+    terms_l = model_data["terms_l"]
+    terms_m = model_data["terms_m"]
+    terms = list(zip(terms_l.tolist(), terms_m.tolist()))
+    n_timepoints = int(model_data["n_timepoints"])
+    noise_variance = model_data.get("noise_variance", None)
+
+    with open(model_dir / "config.json") as f:
+        config = json.load(f)
+
+    # Output directory
+    fig_dir = output if output else model_dir / "figures"
+    fig_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Harmonics timeseries
+    plot_harmonics_timeseries(X_freq, terms, n_timepoints, fig_dir / "harmonics_timeseries.png")
+    typer.echo(f"Saved harmonics_timeseries.png")
+
+    # 2. Residuals (needs original data)
+    if data is not None:
+        plot_residuals(X_freq, ST, n_timepoints, data, config, fig_dir / "residuals.png")
+        typer.echo(f"Saved residuals.png")
+
+    # 3. Noise variance
+    if noise_variance is not None:
+        plot_noise_variance(noise_variance, fig_dir / "noise_variance.png")
+        typer.echo(f"Saved noise_variance.png")
+
+    # 4. Power spectrum
+    if data is not None:
+        plot_power_spectrum(X_freq, ST, n_timepoints, data, config, fig_dir / "power_spectrum.png")
+        typer.echo(f"Saved power_spectrum.png")
+
+    # 5. Spatial snapshot
+    plot_spatial_snapshot(X_freq, terms, n_timepoints, config, fig_dir / "spatial_snapshot.png")
+    typer.echo(f"Saved spatial_snapshot.png")
+
+    typer.echo(f"All figures saved to: {fig_dir}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/fnirs/plotting.py
+++ b/src/fnirs/plotting.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Plotting functions for fnirs model visualization."""
+
+import json
+from pathlib import Path
+from typing import List, Tuple, Optional
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def plot_harmonics_timeseries(
+    X_freq: np.ndarray,
+    terms: List[Tuple[int, int]],
+    n_timepoints: int,
+    output_path: Path,
+):
+    """Plot amplitude of each spherical harmonic component over time.
+
+    For each (l, m) pair, compute the time-domain signal via IRFFT.
+    Plot grouped by degree l with different colors per m.
+    """
+    max_l = max(t[0] for t in terms)
+
+    fig, axes = plt.subplots(max_l + 1, 1, figsize=(12, 3 * (max_l + 1)), sharex=True)
+    if max_l == 0:
+        axes = [axes]
+
+    cmap = plt.cm.tab10
+
+    for l_deg in range(max_l + 1):
+        ax = axes[l_deg]
+        m_values = [t[1] for t in terms if t[0] == l_deg]
+        indices = [i for i, t in enumerate(terms) if t[0] == l_deg]
+
+        for idx, (i, m) in enumerate(zip(indices, m_values)):
+            signal = np.fft.irfft(X_freq[i, :], n=n_timepoints)
+            color = cmap(idx % 10)
+            ax.plot(signal, color=color, label=f"m={m}", alpha=0.8, linewidth=0.8)
+
+        ax.set_ylabel(f"l={l_deg}")
+        ax.legend(loc="upper right", fontsize=7, ncol=min(len(m_values), 5))
+        ax.grid(True, alpha=0.3)
+
+    axes[-1].set_xlabel("Time (samples)")
+    fig.suptitle("Spherical Harmonic Amplitudes over Time", fontsize=13)
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_residuals(
+    X_freq: np.ndarray,
+    ST: np.ndarray,
+    n_timepoints: int,
+    data_path: Path,
+    config: dict,
+    output_path: Path,
+):
+    """Plot per-channel residual RMS."""
+    from fnirs.io import load_hemodynamic_data, load_snirf_data, ChromophoreType
+
+    # Load original data
+    if str(data_path).endswith(".snirf"):
+        nirs_data = load_snirf_data(str(data_path))
+        Y = nirs_data.time_series.T
+    else:
+        hemo_data = load_hemodynamic_data(str(data_path))
+        chrom_map = {"hbo": ChromophoreType.HbO, "hbr": ChromophoreType.HbR, "hbt": ChromophoreType.HbT}
+        chrom = chrom_map[config.get("chromophore", "hbo").lower()]
+        Y = hemo_data.get_concentration_matrix(chrom).T
+
+    # Predict
+    pred_freq = ST @ X_freq
+    Y_hat = np.fft.irfft(pred_freq, n=n_timepoints, axis=1)
+
+    # Residuals
+    residuals = Y[:, :n_timepoints] - Y_hat
+    rms = np.sqrt(np.mean(residuals ** 2, axis=1))
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.bar(range(len(rms)), rms, color="steelblue", alpha=0.8)
+    ax.set_xlabel("Channel")
+    ax.set_ylabel("Residual RMS")
+    ax.set_title("Per-Channel Residual RMS")
+    ax.grid(True, alpha=0.3, axis="y")
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_noise_variance(
+    noise_variance: np.ndarray,
+    output_path: Path,
+):
+    """Plot per-channel estimated noise variance (IRLS)."""
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.bar(range(len(noise_variance)), noise_variance, color="coral", alpha=0.8)
+    ax.set_xlabel("Channel")
+    ax.set_ylabel("Noise Variance")
+    ax.set_title("Per-Channel Estimated Noise Variance (IRLS)")
+    ax.grid(True, alpha=0.3, axis="y")
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_power_spectrum(
+    X_freq: np.ndarray,
+    ST: np.ndarray,
+    n_timepoints: int,
+    data_path: Path,
+    config: dict,
+    output_path: Path,
+):
+    """Plot average power spectrum of data vs model prediction."""
+    from fnirs.io import load_hemodynamic_data, load_snirf_data, ChromophoreType
+
+    if str(data_path).endswith(".snirf"):
+        nirs_data = load_snirf_data(str(data_path))
+        Y = nirs_data.time_series.T
+    else:
+        hemo_data = load_hemodynamic_data(str(data_path))
+        chrom_map = {"hbo": ChromophoreType.HbO, "hbr": ChromophoreType.HbR, "hbt": ChromophoreType.HbT}
+        chrom = chrom_map[config.get("chromophore", "hbo").lower()]
+        Y = hemo_data.get_concentration_matrix(chrom).T
+
+    # Data power spectrum
+    Y_freq_data = np.fft.rfft(Y, axis=1)
+    data_power = np.mean(np.abs(Y_freq_data) ** 2, axis=0)
+
+    # Model power spectrum
+    pred_freq = ST @ X_freq
+    model_power = np.mean(np.abs(pred_freq) ** 2, axis=0)
+
+    freqs = np.fft.rfftfreq(Y.shape[1])
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.semilogy(freqs, data_power, label="Data", alpha=0.7, linewidth=0.8)
+    ax.semilogy(freqs[:len(model_power)], model_power, label="Model", alpha=0.7, linewidth=0.8)
+    ax.set_xlabel("Frequency (cycles/sample)")
+    ax.set_ylabel("Power")
+    ax.set_title("Average Power Spectrum: Data vs Model")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_spatial_snapshot(
+    X_freq: np.ndarray,
+    terms: List[Tuple[int, int]],
+    n_timepoints: int,
+    config: dict,
+    output_path: Path,
+    n_snapshots: int = 4,
+):
+    """Plot spatial field on sphere at selected time points."""
+    from scipy.special import sph_harm_y
+
+    # Reconstruct time-domain coefficients for each harmonic
+    # X_time[i, t] = amplitude of harmonic i at time t
+    X_time = np.fft.irfft(X_freq, n=n_timepoints, axis=1)
+
+    # Create grid of (theta, phi) points
+    n_grid = 30
+    theta_grid = np.linspace(0.1, np.pi - 0.1, n_grid)
+    phi_grid = np.linspace(0, 2 * np.pi, n_grid)
+    theta_mesh, phi_mesh = np.meshgrid(theta_grid, phi_grid)
+    theta_flat = theta_mesh.flatten()
+    phi_flat = phi_mesh.flatten()
+
+    # Build basis at grid points
+    n_spatial = len(terms)
+    ST_grid = np.zeros((len(theta_flat), n_spatial))
+    for i, (l, m) in enumerate(terms):
+        Y_val = sph_harm_y(l, m, phi_flat, theta_flat)
+        if m == 0:
+            ST_grid[:, i] = Y_val.real
+        elif m > 0:
+            ST_grid[:, i] = np.sqrt(2) * (-1) ** m * Y_val.real
+        else:
+            ST_grid[:, i] = np.sqrt(2) * (-1) ** m * Y_val.imag
+
+    # Select time points
+    time_indices = np.linspace(0, n_timepoints - 1, n_snapshots, dtype=int)
+
+    fig, axes = plt.subplots(1, n_snapshots, figsize=(4 * n_snapshots, 3.5),
+                             subplot_kw={"projection": "mollweide"})
+    if n_snapshots == 1:
+        axes = [axes]
+
+    for ax, t_idx in zip(axes, time_indices):
+        coeffs = X_time[:, t_idx]
+        field = ST_grid @ coeffs
+        field_2d = field.reshape(theta_mesh.shape)
+
+        # Mollweide projection expects lon in [-pi, pi], lat in [-pi/2, pi/2]
+        lon = phi_mesh - np.pi
+        lat = np.pi / 2 - theta_mesh
+
+        vmax = np.max(np.abs(field_2d))
+        im = ax.pcolormesh(lon, lat, field_2d, cmap="RdBu_r", vmin=-vmax, vmax=vmax, shading="auto")
+        ax.set_title(f"t={t_idx}", fontsize=10)
+        ax.grid(True, alpha=0.3)
+
+    fig.colorbar(im, ax=axes, orientation="horizontal", fraction=0.05, pad=0.08)
+    fig.suptitle("Spatial Field Snapshots", fontsize=13)
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)

--- a/test_cli.py
+++ b/test_cli.py
@@ -1,0 +1,119 @@
+"""Tests for the fnirs CLI and plotting functions."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from fnirs.cli import app
+from fnirs.plotting import (
+    plot_harmonics_timeseries,
+    plot_noise_variance,
+    plot_spatial_snapshot,
+)
+
+runner = CliRunner()
+
+
+def test_main_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "fit" in result.output
+    assert "plot" in result.output
+
+
+def test_fit_help():
+    result = runner.invoke(app, ["fit", "--help"])
+    assert result.exit_code == 0
+    assert "--data" in result.output
+    assert "--max-degree" in result.output
+    assert "--estimate-noise" in result.output
+
+
+def test_plot_help():
+    result = runner.invoke(app, ["plot", "--help"])
+    assert result.exit_code == 0
+    assert "--model-dir" in result.output
+    assert "--data" in result.output
+
+
+def _make_synthetic_model(tmp_path: Path, with_noise: bool = False):
+    """Create a synthetic model output for testing."""
+    n_spatial = 4  # l=0 (1) + l=1 (3)
+    n_freq = 33
+    n_timepoints = 64
+    rng = np.random.default_rng(0)
+
+    X_freq = rng.standard_normal((n_spatial, n_freq)) + 1j * rng.standard_normal((n_spatial, n_freq))
+    ST = rng.standard_normal((10, n_spatial))
+    terms_l = np.array([0, 1, 1, 1])
+    terms_m = np.array([0, -1, 0, 1])
+
+    save_dict = dict(
+        X_freq_real=X_freq.real,
+        X_freq_imag=X_freq.imag,
+        ST=ST,
+        n_timepoints=n_timepoints,
+        terms_l=terms_l,
+        terms_m=terms_m,
+    )
+    if with_noise:
+        save_dict["noise_variance"] = rng.uniform(0.01, 0.1, size=10)
+
+    np.savez(tmp_path / "model.npz", **save_dict)
+
+    config = dict(
+        data="synthetic",
+        max_degree=1,
+        n_fourier=None,
+        chromophore="hbo",
+        temporal_kernel=None,
+        kernel_lengthscale=1.0,
+        kernel_variance=1.0,
+        estimate_noise=with_noise,
+        max_irls_iter=20,
+        irls_tol=1e-4,
+        seed=42,
+    )
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(config, f)
+
+    return X_freq, ST, terms_l, terms_m, n_timepoints
+
+
+def test_plot_harmonics_timeseries(tmp_path):
+    X_freq, ST, terms_l, terms_m, n_timepoints = _make_synthetic_model(tmp_path)
+    terms = list(zip(terms_l.tolist(), terms_m.tolist()))
+    out = tmp_path / "harmonics.png"
+    plot_harmonics_timeseries(X_freq, terms, n_timepoints, out)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_plot_noise_variance(tmp_path):
+    noise = np.random.uniform(0.01, 0.1, size=10)
+    out = tmp_path / "noise.png"
+    plot_noise_variance(noise, out)
+    assert out.exists()
+
+
+def test_plot_spatial_snapshot(tmp_path):
+    X_freq, ST, terms_l, terms_m, n_timepoints = _make_synthetic_model(tmp_path)
+    terms = list(zip(terms_l.tolist(), terms_m.tolist()))
+    config = {"max_degree": 1}
+    out = tmp_path / "spatial.png"
+    plot_spatial_snapshot(X_freq, terms, n_timepoints, config, out, n_snapshots=2)
+    assert out.exists()
+
+
+def test_plot_subcommand_with_synthetic(tmp_path):
+    """Test the plot subcommand end-to-end with synthetic data."""
+    _make_synthetic_model(tmp_path, with_noise=True)
+    result = runner.invoke(app, ["plot", "--model-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert (tmp_path / "figures" / "harmonics_timeseries.png").exists()
+    assert (tmp_path / "figures" / "noise_variance.png").exists()
+    assert (tmp_path / "figures" / "spatial_snapshot.png").exists()


### PR DESCRIPTION
## Summary

- Adds `fnirs fit` CLI subcommand for fitting spatial-temporal models from the command line with full control over GP/IRLS options
- Adds `fnirs plot` CLI subcommand for generating publication-ready figures from fitted models
- Creates `src/fnirs/plotting.py` with five plot types: harmonics timeseries, residuals, noise variance, power spectrum, and spatial snapshots
- Adds `[project.scripts]` entry point in pyproject.toml

## Usage

```bash
fnirs fit --data recording.mat --output results/ --max-degree 5 --estimate-noise
fnirs plot --model-dir results/ --data recording.mat
```

## Test plan

- [x] `uv run fnirs --help` shows subcommands
- [x] `uv run fnirs fit --help` shows all options
- [x] `uv run fnirs plot --help` shows all options
- [x] `uv run pytest test_cli.py -v` passes (7 tests)